### PR TITLE
fix: correct notification totals and home run metrics

### DIFF
--- a/backend/app/services/event_detector.py
+++ b/backend/app/services/event_detector.py
@@ -47,19 +47,26 @@ def _parse_optional_float(value: object) -> float | None:
         return None
 
 
-def _extract_home_run_metrics(play: dict) -> str:
-    """ホームラン通知に付与する打球データを整形する。"""
+def _find_hit_data(play: dict) -> dict | None:
+    """MLB feed variants may expose hitData on the play or on a playEvent."""
+    candidate = play.get("hitData")
+    if isinstance(candidate, dict) and candidate:
+        return candidate
+
     play_events = play.get("playEvents", [])
     if not isinstance(play_events, list):
-        return ""
+        return None
 
-    hit_data: dict | None = None
     for play_event in reversed(play_events):
         candidate = play_event.get("hitData")
         if isinstance(candidate, dict) and candidate:
-            hit_data = candidate
-            break
+            return candidate
+    return None
 
+
+def _extract_home_run_metrics(play: dict) -> str:
+    """ホームラン通知に付与する打球データを整形する。"""
+    hit_data = _find_hit_data(play)
     if not hit_data:
         return ""
 
@@ -188,45 +195,88 @@ def _build_notification_message(
         return f"{name} イベント発生", f"{name} にイベントが発生しました"
 
 
+def _identify_target_event(play: dict) -> tuple[str, int, str, int] | None:
+    result = play.get("result", {})
+    about = play.get("about", {})
+    matchup = play.get("matchup", {})
+
+    event_name = result.get("event", "")
+    event_type = EVENT_MAP.get(event_name)
+    if not event_type:
+        return None
+
+    if not about.get("isComplete", False):
+        return None
+
+    at_bat_index = about.get("atBatIndex", -1)
+    batter_id = matchup.get("batter", {}).get("id", 0)
+    batter_name = matchup.get("batter", {}).get("fullName", "")
+    pitcher_id = matchup.get("pitcher", {}).get("id", 0)
+    pitcher_name = matchup.get("pitcher", {}).get("fullName", "")
+
+    if event_type == "home_run" and batter_id in BATTER_IDS:
+        return event_type, batter_id, pitcher_name, at_bat_index
+    if event_type == "strikeout" and pitcher_id in PITCHER_IDS:
+        return event_type, pitcher_id, batter_name, at_bat_index
+    return None
+
+
+def _adjust_total_for_pending_events(total: int | None, remaining_pending_count: int) -> int | None:
+    if total is None:
+        return None
+    return max(total - max(remaining_pending_count - 1, 0), 0)
+
+
+async def _count_pending_new_events(
+    plays: list[dict],
+    game_pk: int,
+    redis: Redis,
+) -> dict[tuple[int, str], int]:
+    counts: dict[tuple[int, str], int] = {}
+    last_indexes: dict[int, int] = {}
+
+    for play in plays:
+        identified = _identify_target_event(play)
+        if identified is None:
+            continue
+
+        event_type, player_id, _, at_bat_index = identified
+        if player_id not in last_indexes:
+            last_indexes[player_id] = await _get_last_at_bat_index(redis, player_id, game_pk)
+        if at_bat_index <= last_indexes[player_id]:
+            continue
+
+        key = (player_id, event_type)
+        counts[key] = counts.get(key, 0) + 1
+
+    return counts
+
+
 async def _process_play(
     play: dict,
     game_pk: int,
     redis: Redis,
     db: AsyncSession,
     http_client: httpx.AsyncClient,
+    pending_event_counts: dict[tuple[int, str], int] | None = None,
 ) -> None:
     """1プレイを解析してイベント検知・通知を行う"""
     try:
-        result = play.get("result", {})
-        about = play.get("about", {})
-        matchup = play.get("matchup", {})
-
-        event_name = result.get("event", "")
-        event_type = EVENT_MAP.get(event_name)
-        if not event_type:
+        identified = _identify_target_event(play)
+        if identified is None:
             return
-
-        at_bat_index: int = about.get("atBatIndex", -1)
-        if not about.get("isComplete", False):
-            return
-
-        batter_id: int = matchup.get("batter", {}).get("id", 0)
-        batter_name: str = matchup.get("batter", {}).get("fullName", "")
-        pitcher_id: int = matchup.get("pitcher", {}).get("id", 0)
-        pitcher_name: str = matchup.get("pitcher", {}).get("fullName", "")
-
-        # 日本人選手かどうか判定
-        if event_type == "home_run" and batter_id in BATTER_IDS:
-            player_id = batter_id
-        elif event_type == "strikeout" and pitcher_id in PITCHER_IDS:
-            player_id = pitcher_id
-        else:
-            return
+        event_type, player_id, opponent_name, at_bat_index = identified
 
         # Redis重複チェック
         last_index = await _get_last_at_bat_index(redis, player_id, game_pk)
         if at_bat_index <= last_index:
             return
+
+        pending_key = (player_id, event_type)
+        remaining_pending_count = 1
+        if pending_event_counts is not None:
+            remaining_pending_count = max(pending_event_counts.get(pending_key, 1), 1)
+            pending_event_counts[pending_key] = max(remaining_pending_count - 1, 0)
 
         # 新規イベント: Redis更新
         await _set_last_at_bat_index(redis, player_id, game_pk, at_bat_index)
@@ -248,8 +298,9 @@ async def _process_play(
             player_id,
             event_type,
         )
+        season_total = _adjust_total_for_pending_events(season_total, remaining_pending_count)
+        career_total = _adjust_total_for_pending_events(career_total, remaining_pending_count)
 
-        opponent_name = pitcher_name if event_type == "home_run" else batter_name
         home_run_metrics = _extract_home_run_metrics(play) if event_type == "home_run" else ""
         title, body = _build_notification_message(
             player_id,
@@ -301,5 +352,6 @@ async def detect_events(
             continue
 
         plays = extract_plays(feed)
+        pending_event_counts = await _count_pending_new_events(plays, game_pk, redis)
         for play in plays:
-            await _process_play(play, game_pk, redis, db, http_client)
+            await _process_play(play, game_pk, redis, db, http_client, pending_event_counts)

--- a/backend/tests/test_event_detector.py
+++ b/backend/tests/test_event_detector.py
@@ -1,4 +1,11 @@
-from app.services.event_detector import _build_notification_message, _extract_home_run_metrics
+import pytest
+
+from app.services.event_detector import (
+    _adjust_total_for_pending_events,
+    _build_notification_message,
+    _count_pending_new_events,
+    _extract_home_run_metrics,
+)
 
 
 def test_extract_home_run_metrics_formats_metric_values():
@@ -18,6 +25,19 @@ def test_extract_home_run_metrics_formats_metric_values():
     assert _extract_home_run_metrics(play) == " 飛距離 135m / 打球速度 181km/h / 角度 29°。"
 
 
+def test_extract_home_run_metrics_uses_play_level_hit_data():
+    play = {
+        "hitData": {
+            "totalDistance": "400",
+            "launchSpeed": "100",
+            "launchAngle": "30",
+        },
+        "playEvents": [],
+    }
+
+    assert _extract_home_run_metrics(play) == " 飛距離 122m / 打球速度 161km/h / 角度 30°。"
+
+
 def test_build_notification_message_appends_home_run_metrics():
     title, body = _build_notification_message(
         660271,
@@ -33,3 +53,53 @@ def test_build_notification_message_appends_home_run_metrics():
     assert "本日2本目" in body
     assert "今シーズン10本目、MLB通算200本目です。" in body
     assert body.endswith("飛距離 135m / 打球速度 181km/h / 角度 29°。")
+
+
+def test_adjust_total_for_pending_events_counts_forward_from_current_total():
+    assert _adjust_total_for_pending_events(700, 2) == 699
+    assert _adjust_total_for_pending_events(700, 1) == 700
+    assert _adjust_total_for_pending_events(None, 2) is None
+
+
+class _FakeRedis:
+    def __init__(self, values: dict[str, int | None]):
+        self.values = values
+
+    async def get(self, key: str) -> int | None:
+        return self.values.get(key)
+
+
+@pytest.mark.anyio
+async def test_count_pending_new_events_ignores_already_processed_plays():
+    game_pk = 12345
+    redis = _FakeRedis({f"last_event:808967:{game_pk}": 6})
+    plays = [
+        {
+            "result": {"event": "Strikeout"},
+            "about": {"atBatIndex": 5, "isComplete": True},
+            "matchup": {
+                "pitcher": {"id": 808967, "fullName": "Yoshinobu Yamamoto"},
+                "batter": {"id": 111, "fullName": "Batter One"},
+            },
+        },
+        {
+            "result": {"event": "Strikeout"},
+            "about": {"atBatIndex": 7, "isComplete": True},
+            "matchup": {
+                "pitcher": {"id": 808967, "fullName": "Yoshinobu Yamamoto"},
+                "batter": {"id": 222, "fullName": "Batter Two"},
+            },
+        },
+        {
+            "result": {"event": "Strikeout"},
+            "about": {"atBatIndex": 8, "isComplete": True},
+            "matchup": {
+                "pitcher": {"id": 808967, "fullName": "Yoshinobu Yamamoto"},
+                "batter": {"id": 333, "fullName": "Batter Three"},
+            },
+        },
+    ]
+
+    assert await _count_pending_new_events(plays, game_pk, redis) == {
+        (808967, "strikeout"): 2,
+    }


### PR DESCRIPTION
## Summary
- Adjust season/career totals when multiple unprocessed events for the same player are notified in one polling pass
- Reuse event identification while counting pending new plays so already-processed at-bats are ignored
- Extract home run hit metrics from either play-level hitData or playEvents hitData

## Tests
- backend/.venv/bin/python -m pytest backend/tests

Closes #34