### PR TITLE
feat #41: ユーザー向けデモ通知機能を追加（打者ver・投手ver）

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -10,6 +10,8 @@ router.include_router(players.router, prefix="/players", tags=["players"])
 router.include_router(users.register_router, prefix="/users", tags=["users"])
 # GET/PUT /api/v1/preferences with X-Push-Token header
 router.include_router(users.preferences_router, prefix="/preferences", tags=["preferences"])
+# POST /api/v1/users/demo-notification (本番環境でも使用可能)
+router.include_router(users.demo_router, prefix="/users", tags=["users"])
 
 # POST /api/v1/test/send-notification
 # DEBUG=true の時にのみ登録

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -1,7 +1,9 @@
 import logging
-from typing import Annotated
+from typing import Annotated, Literal
 
+import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import BaseModel
 from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,9 +20,11 @@ from app.schemas.user import (
     RegisterRequest,
     RegisterResponse,
 )
+from app.services.notification import send_notifications
 
 register_router = APIRouter()
 preferences_router = APIRouter()
+demo_router = APIRouter()
 logger = logging.getLogger(__name__)
 
 LEGACY_PLAYER_ID_MAP: dict[int, int] = {
@@ -388,3 +392,45 @@ async def update_player_event_prefs(
             pref.is_enabled = is_enabled
 
     await db.commit()
+
+
+class UserDemoNotificationRequest(BaseModel):
+    demo_type: Literal["batter", "pitcher"] = "batter"
+
+
+@demo_router.post("/demo-notification", status_code=status.HTTP_204_NO_CONTENT)
+async def send_user_demo_notification(
+    body: UserDemoNotificationRequest,
+    push_token: PushTokenHeader,
+    db: AsyncSession = Depends(get_db),
+):
+    """ユーザー向けデモ通知を送信する（打者ver・投手ver）。本番環境でも使用可能。"""
+    await _get_existing_user_or_404(db, push_token)
+
+    if body.demo_type == "batter":
+        title = "⚾ 大谷翔平 ホームラン！"
+        message = (
+            "大谷翔平選手がホームランを打ちました（対 Kyle Finnegan）！"
+            "これがこのアプリからの通知サンプルです。"
+        )
+    else:
+        title = "🔥 山本由伸 奪三振！"
+        message = (
+            "山本由伸選手が三振を奪いました（Alec Bohmから）！"
+            "これがこのアプリからの通知サンプルです。"
+        )
+
+    async with httpx.AsyncClient() as client:
+        try:
+            await send_notifications(
+                client,
+                [push_token],
+                title=title,
+                body=message,
+                data={"type": "demo", "demo_type": body.demo_type},
+            )
+        except httpx.HTTPError as e:
+            raise HTTPException(
+                status_code=502,
+                detail=f"Expo Push APIへの送信に失敗しました: {e}",
+            ) from e

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -21,6 +21,7 @@ from app.schemas.user import (
     RegisterResponse,
 )
 from app.services.notification import send_notifications
+from app.services.scheduler import get_http_client
 
 register_router = APIRouter()
 preferences_router = APIRouter()
@@ -403,6 +404,7 @@ async def send_user_demo_notification(
     body: UserDemoNotificationRequest,
     push_token: PushTokenHeader,
     db: AsyncSession = Depends(get_db),
+    http_client: httpx.AsyncClient = Depends(get_http_client),
 ):
     """ユーザー向けデモ通知を送信する（打者ver・投手ver）。本番環境でも使用可能。"""
     await _get_existing_user_or_404(db, push_token)
@@ -420,17 +422,17 @@ async def send_user_demo_notification(
             "これがこのアプリからの通知サンプルです。"
         )
 
-    async with httpx.AsyncClient() as client:
-        try:
-            await send_notifications(
-                client,
-                [push_token],
-                title=title,
-                body=message,
-                data={"type": "demo", "demo_type": body.demo_type},
-            )
-        except httpx.HTTPError as e:
-            raise HTTPException(
-                status_code=502,
-                detail=f"Expo Push APIへの送信に失敗しました: {e}",
-            ) from e
+    try:
+        await send_notifications(
+            http_client,
+            [push_token],
+            title=title,
+            body=message,
+            data={"type": "demo", "demo_type": body.demo_type},
+        )
+    except Exception as e:
+        logger.error("send_user_demo_notification failed: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=502,
+            detail="通知の送信に失敗しました。しばらくしてからお試しください。",
+        ) from e

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -268,3 +268,10 @@ async def stop_scheduler() -> None:
     if _http_client:
         await _http_client.aclose()
         _http_client = None
+
+
+def get_http_client() -> httpx.AsyncClient:
+    """lifespan で管理された共有 AsyncClient を返す。未初期化時は RuntimeError を送出する。"""
+    if _http_client is None:
+        raise RuntimeError("HTTP client is not initialized (scheduler not started)")
+    return _http_client

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -20,7 +20,7 @@
         "NSUserNotificationUsageDescription": "MLB日本人選手のホームランや奪三振をリアルタイムで通知するために使用します。",
         "ITSAppUsesNonExemptEncryption": false
       },
-      "buildNumber": "7"
+      "buildNumber": "10"
     },
     "android": {
       "package": "com.mlb.notification",

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -18,6 +18,7 @@ import {
   deactivateCurrentUser,
   sendDemoNotification,
   sendTestNotification,
+  sendUserDemoNotification,
 } from "@/lib/api";
 import { clearPushToken } from "@/lib/storage";
 import type { Player } from "@/types/api";
@@ -119,9 +120,12 @@ export default function SettingsScreen() {
   const [isDeactivating, setIsDeactivating] = useState(false);
   const [isBulkUpdating, setIsBulkUpdating] = useState(false);
   const [testResult, setTestResult] = useState<{ ok: boolean; msg: string } | null>(null);
+  const [isDemoSending, setIsDemoSending] = useState(false);
+  const [demoResult, setDemoResult] = useState<{ ok: boolean; msg: string } | null>(null);
 
   const handleRefresh = useCallback(async () => {
     setTestResult(null);
+    setDemoResult(null);
     await refresh();
   }, [refresh]);
 
@@ -150,6 +154,20 @@ export default function SettingsScreen() {
       setTestResult({ ok: false, msg: e instanceof Error ? e.message : "送信に失敗しました" });
     } finally {
       setIsTesting(false);
+    }
+  };
+
+  const handleSendUserDemo = async (demoType: "batter" | "pitcher") => {
+    if (!token) return;
+    setIsDemoSending(true);
+    setDemoResult(null);
+    try {
+      await sendUserDemoNotification(token, demoType);
+      setDemoResult({ ok: true, msg: "通知を送信しました。数秒後に届きます。" });
+    } catch (e) {
+      setDemoResult({ ok: false, msg: e instanceof Error ? e.message : "送信に失敗しました" });
+    } finally {
+      setIsDemoSending(false);
     }
   };
 
@@ -262,6 +280,45 @@ export default function SettingsScreen() {
             ))}
           </View>
         ))}
+      </View>
+
+      {/* 通知を体験する */}
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>通知を体験する</Text>
+        <Text style={styles.helpText}>
+          実際にどんな通知が届くかをお試しいただけます。
+        </Text>
+        <View style={styles.demoGrid}>
+          <TouchableOpacity
+            style={[styles.demoButton, isDemoSending && styles.testButtonDisabled]}
+            onPress={() => handleSendUserDemo("batter")}
+            disabled={isDemoSending || !token}
+            activeOpacity={0.7}
+          >
+            {isDemoSending ? (
+              <ActivityIndicator size="small" color={Colors.text} />
+            ) : (
+              <Text style={styles.demoButtonText}>打者通知を体験</Text>
+            )}
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.demoButton, isDemoSending && styles.testButtonDisabled]}
+            onPress={() => handleSendUserDemo("pitcher")}
+            disabled={isDemoSending || !token}
+            activeOpacity={0.7}
+          >
+            {isDemoSending ? (
+              <ActivityIndicator size="small" color={Colors.text} />
+            ) : (
+              <Text style={styles.demoButtonText}>投手通知を体験</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+        {demoResult && (
+          <Text style={[styles.testResultText, demoResult.ok ? styles.testResultOk : styles.testResultError]}>
+            {demoResult.msg}
+          </Text>
+        )}
       </View>
 
       <View style={styles.section}>

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,10 @@
+// https://docs.expo.dev/guides/using-eslint/
+const { defineConfig } = require('eslint/config');
+const expoConfig = require("eslint-config-expo/flat");
+
+module.exports = defineConfig([
+  expoConfig,
+  {
+    ignores: ["dist/*"],
+  }
+]);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -159,6 +159,17 @@ export async function updatePlayerEvents(
   });
 }
 
+export async function sendUserDemoNotification(
+  token: string,
+  demoType: "batter" | "pitcher"
+): Promise<void> {
+  return request<void>("/api/v1/users/demo-notification", {
+    method: "POST",
+    headers: authHeaders(token),
+    body: JSON.stringify({ demo_type: demoType }),
+  });
+}
+
 export async function sendTestNotification(token: string): Promise<void> {
   return request<void>("/api/v1/test/send-notification", {
     method: "POST",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.0.4",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.0.4",
+      "version": "1.0.7",
       "dependencies": {
         "expo": "54.0.33",
         "expo-constants": "~18.0.13",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,9 +4,10 @@
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
-    "web": "expo start --web"
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web",
+    "lint": "expo lint"
   },
   "dependencies": {
     "expo": "54.0.33",


### PR DESCRIPTION
## 概要

closes #41

一般ユーザーが実際にどんな通知が届くかをお試しで体験できる機能を追加しました。
打者ver（ホームラン通知）と投手ver（奪三振通知）の2種類を用意しています。

## 背景

既存の通知デモ機能（`/api/v1/test/send-demo-notification`）は `DEBUG=true` の場合のみ有効で、
本番ユーザーが通知の内容を事前に体験する手段がありませんでした。

## 追加した機能

### バックエンド

- **新規エンドポイント** `POST /api/v1/users/demo-notification`
  - `DEBUG` フラグに依存しない（本番環境でも常時有効）
  - `X-Push-Token` ヘッダーで認証し、未登録トークンは 404 を返す
  - リクエストボディ: `{ "demo_type": "batter" | "pitcher" }`
  - 打者ver: 大谷翔平ホームラン通知のサンプルを送信
  - 投手ver: 山本由伸奪三振通知のサンプルを送信

### フロントエンド

- 設定画面に **「通知を体験する」セクション** を常時表示（本番・開発両環境）
  - 「打者通知を体験」「投手通知を体験」の2ボタン
  - 送信中のローディングインジケーター表示
  - 成功・失敗メッセージ表示

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `backend/app/api/v1/users.py` | `demo_router` と `send_user_demo_notification` エンドポイントを追加 |
| `backend/app/api/v1/router.py` | `demo_router` を `/api/v1/users` プレフィックスで登録 |
| `frontend/lib/api.ts` | `sendUserDemoNotification` 関数を追加 |
| `frontend/app/(tabs)/settings.tsx` | 「通知を体験する」セクションを追加 |

## 既存機能への影響

- 開発者向けの `SHOW_TEST_TOOLS = __DEV__` ブロックはそのまま維持
- 既存の `/api/v1/test/send-demo-notification` エンドポイントも変更なし

## Test plan

- [ ] 設定画面に「通知を体験する」セクションが表示されることを確認
- [ ] 「打者通知を体験」ボタンを押すとホームラン通知が届くことを確認
- [ ] 「投手通知を体験」ボタンを押すと奪三振通知が届くことを確認
- [ ] 送信中はボタンがローディング表示になり、無効化されることを確認
- [ ] 成功・失敗メッセージが正しく表示されることを確認
- [ ] 未登録トークンでリクエストした場合に 404 が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)