### PR TITLE
fix #42: increment daily event count before checking subscribers

### DIFF
--- a/backend/app/services/event_detector.py
+++ b/backend/app/services/event_detector.py
@@ -21,6 +21,8 @@ from app.services.notification import send_notifications
 
 logger = logging.getLogger(__name__)
 
+_JST = ZoneInfo("Asia/Tokyo")
+
 # fire-and-forget タスクをGCされないよう保持するセット
 _background_tasks: set[asyncio.Task] = set()
 
@@ -38,6 +40,7 @@ EVENT_MAP = {
 }
 
 REDIS_TTL = 86400  # 24時間
+REDIS_DAILY_COUNT_TTL = 172800  # 2日（日付跨ぎ遅延を吸収）
 
 
 def _parse_optional_float(value: object) -> float | None:
@@ -98,18 +101,22 @@ async def _set_last_at_bat_index(redis: Redis, player_id: int, game_pk: int, at_
     await redis.set(key, at_bat_index, ex=REDIS_TTL)
 
 
+def _jst_date_str() -> str:
+    return datetime.now(_JST).strftime("%Y%m%d")
+
+
 async def _increment_and_get_daily_event_count(
     redis: Redis,
     player_id: int,
     event_type: str,
 ) -> int:
     """当日中の選手別イベント数をインクリメントして返す"""
-    jst_date = datetime.now(ZoneInfo("Asia/Tokyo")).strftime("%Y%m%d")
+    jst_date = _jst_date_str()
     key = f"daily_event_count:{jst_date}:{player_id}:{event_type}"
     count = await redis.incr(key)
     # 日付を跨いだ遅延処理も吸収できるよう2日保持
     if count == 1:
-        await redis.expire(key, 172800)
+        await redis.expire(key, REDIS_DAILY_COUNT_TTL)
     return int(count)
 
 
@@ -222,6 +229,10 @@ def _identify_target_event(play: dict) -> tuple[str, int, str, int] | None:
 
 
 def _adjust_total_for_pending_events(total: int | None, remaining_pending_count: int) -> int | None:
+    """`remaining_pending_count` 個の未処理イベントのうち現在処理中の1件を除いた先行未処理件数分だけ
+    `total` を遡らせる。Stats API が最新イベント込みの値を返す場合に、先行イベント分の重複を除くために
+    使用する。`total` が None の場合は None を返す。
+    """
     if total is None:
         return None
     return max(total - max(remaining_pending_count - 1, 0), 0)
@@ -260,7 +271,12 @@ async def _process_play(
     http_client: httpx.AsyncClient,
     pending_event_counts: dict[tuple[int, str], int] | None = None,
 ) -> None:
-    """1プレイを解析してイベント検知・通知を行う"""
+    """1プレイを解析してイベント検知・通知を行う。
+
+    設計上の注意: カウンターは通知送信の成否に関わらずインクリメントされる。例外発生時に通知が
+    失われてもカウンターは戻らない（at-most-once 通知）。これは subscribers 不在時のカウント欠損
+    （issue #42）よりも許容できる副作用として意図的に選択した仕様である。
+    """
     try:
         identified = _identify_target_event(play)
         if identified is None:
@@ -273,6 +289,8 @@ async def _process_play(
             return
 
         pending_key = (player_id, event_type)
+        # pending_event_counts=None は POST_GAME 追い込み以外の通常呼出しを示す。
+        # remaining_pending_count=1 となり _adjust_total_for_pending_events は total を変化させない（補正不要）。
         remaining_pending_count = 1
         if pending_event_counts is not None:
             remaining_pending_count = max(pending_event_counts.get(pending_key, 1), 1)

--- a/backend/app/services/event_detector.py
+++ b/backend/app/services/event_detector.py
@@ -286,13 +286,16 @@ async def _process_play(
             player_id, event_type, game_pk, at_bat_index,
         )
 
+        # subscribers の有無に関わらずカウンターを進める
+        # （subscribers がいない間のイベントもカウントに含め、後続通知での過少カウントを防ぐ）
+        today_count = await _increment_and_get_daily_event_count(redis, player_id, event_type)
+
         # 通知対象ユーザー取得
         tokens = await _get_target_users(db, player_id, event_type)
         if not tokens:
             logger.debug("No subscribers for player=%s event=%s", player_id, event_type)
             return
 
-        today_count = await _increment_and_get_daily_event_count(redis, player_id, event_type)
         season_total, career_total = await get_player_event_totals(
             http_client,
             player_id,

--- a/backend/tests/test_event_detector.py
+++ b/backend/tests/test_event_detector.py
@@ -85,6 +85,20 @@ def test_build_notification_message_strikeout_with_season_and_career_total():
     assert "MLB通算200個目" in body
 
 
+def test_build_notification_message_strikeout_first_career():
+    title, body = _build_notification_message(
+        808967,
+        "strikeout",
+        today_count=1,
+        season_total=1,
+        career_total=1,
+        opponent_name="Mike Trout",
+    )
+    assert title == "🔥 山本由伸 奪三振！"
+    assert "本日1個目" in body
+    assert "これがMLB初奪三振です" in body
+
+
 def test_adjust_total_for_pending_events_counts_forward_from_current_total():
     assert _adjust_total_for_pending_events(700, 2) == 699
     assert _adjust_total_for_pending_events(700, 1) == 700
@@ -180,6 +194,7 @@ async def test_process_play_increments_daily_count_even_when_no_subscribers():
         patch("app.services.event_detector._get_target_users", return_value=[]),
         patch("app.services.event_detector._get_last_at_bat_index", return_value=-1),
         patch("app.services.event_detector._set_last_at_bat_index"),
+        patch("app.services.event_detector._jst_date_str", return_value="20240101"),
     ):
         await _process_play(
             play,
@@ -189,8 +204,7 @@ async def test_process_play_increments_daily_count_even_when_no_subscribers():
             http_client=AsyncMock(),
         )
 
-    jst_date = datetime.now(ZoneInfo("Asia/Tokyo")).strftime("%Y%m%d")
-    key = f"daily_event_count:{jst_date}:808967:strikeout"
+    key = "daily_event_count:20240101:808967:strikeout"
     assert fake_redis.values.get(key) == 1
 
 

--- a/backend/tests/test_event_detector.py
+++ b/backend/tests/test_event_detector.py
@@ -15,6 +15,13 @@ from app.services.event_detector import (
 )
 
 
+@pytest.fixture(autouse=True)
+def clear_background_tasks():
+    ed_module._background_tasks.clear()
+    yield
+    ed_module._background_tasks.clear()
+
+
 def test_extract_home_run_metrics_formats_metric_values():
     play = {
         "playEvents": [
@@ -199,9 +206,6 @@ async def test_process_play_multiple_pending_events_increment_n_and_m_correctly(
     - play2: remaining=2 → season=49, career=199
     - play3: remaining=1 → season=50, career=200
     """
-    # 他テストが追加した残留タスクを排除してテスト隔離を保証する
-    ed_module._background_tasks.clear()
-
     fake_redis = _FakeRedisWithIncr()
     game_pk = 99999
     player_id = 808967

--- a/backend/tests/test_event_detector.py
+++ b/backend/tests/test_event_detector.py
@@ -189,11 +189,19 @@ async def test_process_play_increments_daily_count_even_when_no_subscribers():
 
 @pytest.mark.anyio
 async def test_process_play_multiple_pending_events_increment_n_and_m_correctly():
-    """3つの未処理奪三振イベントを順に処理したとき、n=1,2,3 と m=198,199,200 が正しく出ること。
+    """3つの未処理奪三振イベントを順に処理したとき、n=1,2,3 と season/career が正しく出ること。
 
     pending_event_counts による _adjust_total_for_pending_events の補正と
     today_count の連番インクリメントが正しく連携していることを確認する。
+
+    get_player_event_totals が (50, 200) を返すとき:
+    - play1: remaining=3 → season=48, career=198
+    - play2: remaining=2 → season=49, career=199
+    - play3: remaining=1 → season=50, career=200
     """
+    # 他テストが追加した残留タスクを排除してテスト隔離を保証する
+    ed_module._background_tasks.clear()
+
     fake_redis = _FakeRedisWithIncr()
     game_pk = 99999
     player_id = 808967
@@ -227,15 +235,18 @@ async def test_process_play_multiple_pending_events_increment_n_and_m_correctly(
                 http_client=AsyncMock(),
                 pending_event_counts=pending_event_counts,
             )
-        # fire-and-forget タスクを _background_tasks から flush する
-        tasks = list(ed_module._background_tasks)
-        if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
+        # このテストで作成した fire-and-forget タスクのみ flush する
+        created_tasks = list(ed_module._background_tasks)
+        if created_tasks:
+            await asyncio.gather(*created_tasks, return_exceptions=True)
 
     assert len(captured_bodies) == 3
     assert "本日1個目" in captured_bodies[0]
     assert "本日2個目" in captured_bodies[1]
     assert "本日3個目" in captured_bodies[2]
+    assert "今シーズン48個目" in captured_bodies[0]
+    assert "今シーズン49個目" in captured_bodies[1]
+    assert "今シーズン50個目" in captured_bodies[2]
     assert "MLB通算198個目" in captured_bodies[0]
     assert "MLB通算199個目" in captured_bodies[1]
     assert "MLB通算200個目" in captured_bodies[2]

--- a/backend/tests/test_event_detector.py
+++ b/backend/tests/test_event_detector.py
@@ -1,10 +1,17 @@
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+from zoneinfo import ZoneInfo
+
 import pytest
 
+import app.services.event_detector as ed_module
 from app.services.event_detector import (
     _adjust_total_for_pending_events,
     _build_notification_message,
     _count_pending_new_events,
     _extract_home_run_metrics,
+    _process_play,
 )
 
 
@@ -55,6 +62,22 @@ def test_build_notification_message_appends_home_run_metrics():
     assert body.endswith("飛距離 135m / 打球速度 181km/h / 角度 29°。")
 
 
+def test_build_notification_message_strikeout_with_season_and_career_total():
+    title, body = _build_notification_message(
+        808967,
+        "strikeout",
+        today_count=2,
+        season_total=50,
+        career_total=200,
+        opponent_name="Mike Trout",
+    )
+
+    assert title == "🔥 山本由伸 奪三振！"
+    assert "本日2個目" in body
+    assert "今シーズン50個目" in body
+    assert "MLB通算200個目" in body
+
+
 def test_adjust_total_for_pending_events_counts_forward_from_current_total():
     assert _adjust_total_for_pending_events(700, 2) == 699
     assert _adjust_total_for_pending_events(700, 1) == 700
@@ -67,6 +90,37 @@ class _FakeRedis:
 
     async def get(self, key: str) -> int | None:
         return self.values.get(key)
+
+
+class _FakeRedisWithIncr:
+    """incr / expire / set / get をサポートする FakeRedis"""
+
+    def __init__(self, values: dict | None = None):
+        self.values: dict[str, int] = values or {}
+
+    async def get(self, key: str) -> int | None:
+        return self.values.get(key)
+
+    async def set(self, key: str, value: int, ex: int | None = None) -> None:
+        self.values[key] = value
+
+    async def incr(self, key: str) -> int:
+        self.values[key] = self.values.get(key, 0) + 1
+        return self.values[key]
+
+    async def expire(self, key: str, seconds: int) -> None:
+        pass  # TTL は無視
+
+
+def _make_strikeout_play(at_bat_index: int, batter_id: int, pitcher_id: int = 808967) -> dict:
+    return {
+        "result": {"event": "Strikeout"},
+        "about": {"atBatIndex": at_bat_index, "isComplete": True},
+        "matchup": {
+            "pitcher": {"id": pitcher_id, "fullName": "Yoshinobu Yamamoto"},
+            "batter": {"id": batter_id, "fullName": f"Batter {batter_id}"},
+        },
+    }
 
 
 @pytest.mark.anyio
@@ -103,3 +157,85 @@ async def test_count_pending_new_events_ignores_already_processed_plays():
     assert await _count_pending_new_events(plays, game_pk, redis) == {
         (808967, "strikeout"): 2,
     }
+
+
+@pytest.mark.anyio
+async def test_process_play_increments_daily_count_even_when_no_subscribers():
+    """subscribers がいなくても today_count がインクリメントされることを確認する回帰テスト。
+
+    修正前（today_count のインクリメントが _get_target_users の後にあった場合）は
+    このテストが失敗する。今回の修正でインクリメント位置を前に移動したことを検証する。
+    """
+    fake_redis = _FakeRedisWithIncr()
+    play = _make_strikeout_play(at_bat_index=10, batter_id=111)
+
+    with (
+        patch("app.services.event_detector._get_target_users", return_value=[]),
+        patch("app.services.event_detector._get_last_at_bat_index", return_value=-1),
+        patch("app.services.event_detector._set_last_at_bat_index"),
+    ):
+        await _process_play(
+            play,
+            game_pk=99999,
+            redis=fake_redis,
+            db=AsyncMock(),
+            http_client=AsyncMock(),
+        )
+
+    jst_date = datetime.now(ZoneInfo("Asia/Tokyo")).strftime("%Y%m%d")
+    key = f"daily_event_count:{jst_date}:808967:strikeout"
+    assert fake_redis.values.get(key) == 1
+
+
+@pytest.mark.anyio
+async def test_process_play_multiple_pending_events_increment_n_and_m_correctly():
+    """3つの未処理奪三振イベントを順に処理したとき、n=1,2,3 と m=198,199,200 が正しく出ること。
+
+    pending_event_counts による _adjust_total_for_pending_events の補正と
+    today_count の連番インクリメントが正しく連携していることを確認する。
+    """
+    fake_redis = _FakeRedisWithIncr()
+    game_pk = 99999
+    player_id = 808967
+
+    plays = [
+        _make_strikeout_play(at_bat_index=5, batter_id=111),
+        _make_strikeout_play(at_bat_index=7, batter_id=222),
+        _make_strikeout_play(at_bat_index=8, batter_id=333),
+    ]
+
+    captured_bodies: list[str] = []
+
+    async def fake_send_notifications(client, tokens, title, body, data=None):
+        captured_bodies.append(body)
+
+    pending_event_counts = {(player_id, "strikeout"): 3}
+
+    with (
+        patch("app.services.event_detector._get_target_users", return_value=["token1"]),
+        patch("app.services.event_detector._get_last_at_bat_index", return_value=-1),
+        patch("app.services.event_detector._set_last_at_bat_index"),
+        patch("app.services.event_detector.get_player_event_totals", return_value=(50, 200)),
+        patch("app.services.event_detector.send_notifications", side_effect=fake_send_notifications),
+    ):
+        for play in plays:
+            await _process_play(
+                play,
+                game_pk=game_pk,
+                redis=fake_redis,
+                db=AsyncMock(),
+                http_client=AsyncMock(),
+                pending_event_counts=pending_event_counts,
+            )
+        # fire-and-forget タスクを _background_tasks から flush する
+        tasks = list(ed_module._background_tasks)
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    assert len(captured_bodies) == 3
+    assert "本日1個目" in captured_bodies[0]
+    assert "本日2個目" in captured_bodies[1]
+    assert "本日3個目" in captured_bodies[2]
+    assert "MLB通算198個目" in captured_bodies[0]
+    assert "MLB通算199個目" in captured_bodies[1]
+    assert "MLB通算200個目" in captured_bodies[2]


### PR DESCRIPTION
## Summary

- `_process_play` 内で `today_count` のインクリメント（`_increment_and_get_daily_event_count`）を `_get_target_users` の呼び出しより前に移動
- subscribers がいない間に発生したイベントも日次カウンターに含まれるようになり、後続の通知で「本日n個目」が過少カウントされるバグを修正

## 変更ファイル

- `backend/app/services/event_detector.py` — カウンターインクリメント位置を修正
- `backend/tests/test_event_detector.py` — 回帰テスト3件を追加

## Test plan

- [ ] `test_process_play_increments_daily_count_even_when_no_subscribers` — subscribers なしでもカウンターが1になることを確認
- [ ] `test_process_play_multiple_pending_events_increment_n_and_m_correctly` — 複数イベントで今日n個目・今シーズンm個目が正しく補正されることを確認
- [ ] `test_build_notification_message_strikeout_with_season_and_career_total` — 奪三振通知フォーマットを確認
- [ ] `pytest tests/test_event_detector.py` — 全8テストがパスすることを確認済み

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)